### PR TITLE
Adding nested sampling functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ endif
 # gfortran
 ifeq ($(strip $(compiler)),gfortran)
   FC = mpif90
-#  FFLAGS = -O0 -Wall -Wextra -fcheck=bounds
-  FFLAGS = -O3
+  FFLAGS = -O0 -Wall -Wextra -fcheck=bounds
+#  FFLAGS = -O3
   FFLAGS += -I/usr/local/include -I$(OBJDIR) -J$(OBJDIR)
   LDFLAGS=-lgcc
   CC=gcc -I$(INCDIR)
@@ -64,7 +64,7 @@ EXE=bontewarlo.run
 SRCFILES=mt19937ar.c kinds.f90 shared_data.f90 io.f90 comms.f90 write_netcdf.f90 write_xyz.f90 \
 	     write_diagnostics.f90 command_line.f90 c_functions.f90 display.f90 \
          energetics.f90 analytics.f90 random_site.f90 metropolis.f90 \
-	     initialise.f90 main.f90
+	     nested_sampling.f90 initialise.f90 main.f90
 
 OBJFILES:=$(SRCFILES:.f90=.o)
 OBJFILES:=$(OBJFILES:.c=.o)
@@ -108,6 +108,7 @@ energetics.o: kinds.o shared_data.o c_functions.o io.o
 analytics.o: shared_data.o kinds.o display.o io.o
 random_site.o: shared_data.o kinds.o c_functions.o analytics.o
 metropolis.o: kinds.o shared_data.o c_functions.o energetics.o random_site.o analytics.o initialise.o
+nested_sampling.o: kinds.o shared_data.o c_functions.o energetics.o random_site.o analytics.o initialise.o metropolis.o
 initialise.o: kinds.o shared_data.o c_functions.o energetics.o random_site.o comms.o
 main.o: initialise.o shared_data.o kinds.o c_functions.o write_netcdf.o\
 	write_xyz.o write_diagnostics.o command_line.o display.o metropolis.o

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you navigate to the `examples` subdirectory, you should find two examples dem
 Most of the options specified in the input file are fairly self-explanatory. The least obvious is the `mode' option. Because it is my intention to include a 2D (and potentially 1D) option in future, the first digit indicates the number of spatial dimensions for the simulation. Then the last two digits the mode. At present, the implemented options are:
 - 01: Simulated Annealing. Uses the Metropolis Monte Carlo algorithm with Kawasaki dynamics to perform simulated annealing on a system in an initially random configuration.
 - 02: Draw Decorellated Samples. Optionally performs simulated annealing then draws samples of the grid N Monte Carlo steps apart. Good for generating supercell configurations for use other methods. *E.g.* this recent reference where the code was used to generate training/test data for a machine-learned interatomic potential: [arXiv:230908689](https://doi.org/10.48550/arXiv.2309.08689).
+- 03: Nested sampling. Uses the nested sampling algorithm to sample the configuration space from random initial configurations, allowing to calculate the partition function at an arbitrary temperature during the post-processing step. 
 
 ## Contributing
 Any/all contributions are welcome via pull requests. 

--- a/src/analytics.f90
+++ b/src/analytics.f90
@@ -22,7 +22,8 @@ module analytics
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   subroutine store_state(averages, config, setup)
-    integer(int16), allocatable, dimension(:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:), intent(in) :: config
     type(run_params), intent(in) :: setup
     real(real64), dimension(:,:,:,:), intent(inout), allocatable :: averages
     integer :: i,j,k,l
@@ -62,7 +63,8 @@ module analytics
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   function total_particle_count(setup, config) result(total_count)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     type(run_params) :: setup
     integer :: total_count
     integer :: i,j,k,b
@@ -90,9 +92,10 @@ module analytics
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   subroutine print_particle_count(setup, config)
-    integer(int16), allocatable, dimension(:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     type(run_params) :: setup
-    integer, dimension(3) :: sizes
+    integer, dimension(4) :: sizes
     integer, dimension(:), allocatable :: species_count
     integer :: i,j,k, n
 
@@ -106,10 +109,10 @@ module analytics
     do k=1, sizes(3)
       do j=1, sizes(2)
         do i=1, sizes(1)
-          if (config(i,j,k) .ne. 0_int16) then
+          if (config(1,i,j,k) .ne. 0_int16) then
             n = n+1
-            species_count(config(i,j,k)) = &
-              species_count(config(i,j,k)) + 1
+            species_count(config(1,i,j,k)) = &
+              species_count(config(1,i,j,k)) + 1
           end if
         end do
       end do
@@ -135,7 +138,8 @@ module analytics
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   subroutine lattice_shells(setup, shells, configuration)
-    integer(int16), dimension(:,:,:,:), allocatable :: configuration
+    !integer(int16), dimension(:,:,:,:), allocatable :: configuration
+    integer(int16), dimension(:,:,:,:) :: configuration
     type(run_params), intent(in) :: setup
     integer :: i,j,k,b,l
     real(real64) :: dist
@@ -214,7 +218,8 @@ module analytics
   subroutine radial_densities(setup, configuration, n_shells,   &
                               shell_distances, r_densities, T)
     type(run_params), intent(in) :: setup
-    integer(int16), dimension(:,:,:,:), allocatable :: configuration
+    !integer(int16), dimension(:,:,:,:), allocatable :: configuration
+    integer(int16), dimension(:,:,:,:) :: configuration
     real(real64), dimension(:), allocatable :: shell_distances
     real(real64), dimension(:,:,:,:), allocatable :: r_densities
     integer, intent(in) :: n_shells, T

--- a/src/display.f90
+++ b/src/display.f90
@@ -83,11 +83,11 @@ module display
   !--------------------------------------------------------------------!
   subroutine display_grid(grid, show_borders, title)
 
-    integer(kind=int16), intent(in), dimension(:,:,:) :: grid
+    integer(kind=int16), intent(in), dimension(:,:,:,:) :: grid
     logical, intent(in), optional :: show_borders
     character(len=*), optional :: title
     logical :: borders
-    integer, dimension(3) :: sizes
+    integer, dimension(4) :: sizes
     integer :: ix, iy, iz
     character(len=1) :: c
     character(len=4), parameter :: clrstr = char(27)//'[2j'
@@ -112,8 +112,8 @@ module display
       do iy = sizes(2), 1, -1
         if (borders) write(*, '(a)', advance='no') '|'
         do ix = 1, sizes(1)
-          if (grid(ix,iy,iz) .ne. 0) then
-            write(c, '(I1)') grid(ix, iy, iz)
+          if (grid(1,ix,iy,iz) .ne. 0) then
+            write(c, '(I1)') grid(1,ix, iy, iz)
           else
             c = ' '
           end if

--- a/src/energetics.f90
+++ b/src/energetics.f90
@@ -22,7 +22,8 @@ module energetics
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   function total_energy(setup,config) result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer :: i, j, k, l
@@ -54,7 +55,8 @@ module energetics
   function bcc_shell1_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -96,7 +98,8 @@ module energetics
   function bcc_shell2_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -136,7 +139,8 @@ module energetics
   function bcc_shell3_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -182,7 +186,8 @@ module energetics
   function bcc_shell4_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -250,7 +255,8 @@ module energetics
   function bcc_shell5_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -293,7 +299,8 @@ module energetics
   function bcc_shell6_energy(setup, site_i, site_j, site_k, &
                              config,  species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -333,7 +340,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_1shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -353,7 +361,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_2shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -374,7 +383,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_3shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -396,7 +406,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_4shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -419,7 +430,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_5shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -443,7 +455,8 @@ module energetics
   !--------------------------------------------------------------------!
   function bcc_energy_6shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -469,7 +482,8 @@ module energetics
   function fcc_shell1_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -515,7 +529,8 @@ module energetics
   function fcc_shell2_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -554,7 +569,8 @@ module energetics
   function fcc_shell3_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -619,7 +635,8 @@ module energetics
   function fcc_shell4_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -665,7 +682,8 @@ module energetics
   function fcc_shell5_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -730,7 +748,8 @@ module energetics
   function fcc_shell6_energy(setup, site_i, site_j, site_k, &
                              config, species)     &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -771,7 +790,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_1shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -791,7 +811,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_2shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -812,7 +833,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_3shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -834,7 +856,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_4shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -857,7 +880,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_5shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -881,7 +905,8 @@ module energetics
   !--------------------------------------------------------------------!
   function fcc_energy_6shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -906,7 +931,8 @@ module energetics
   !--------------------------------------------------------------------!
   function simple_cubic_1shell_energy(setup, site_i, site_j, site_k, config, species) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -950,7 +976,8 @@ module energetics
   !--------------------------------------------------------------------!
   function simple_cubic_energy_1shells(setup, config, site_i, site_j, site_k) &
            result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     real(real64) :: energy
     class(run_params), intent(in) :: setup
     integer, intent(in) :: site_i, site_j, site_k
@@ -969,7 +996,8 @@ module energetics
   !--------------------------------------------------------------------!
   function pair_energy(setup, config, idx1, idx2)&
        result(energy)
-    integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+    integer(int16), dimension(:,:,:,:), intent(in) :: config
     type(run_params), intent(in) :: setup
     integer, dimension(4), intent(in) :: idx1, idx2
     real(real64) :: energy

--- a/src/howto_examples.f90
+++ b/src/howto_examples.f90
@@ -1,0 +1,196 @@
+!----------------------------------------------------------------------!
+!   Examples of how to do basic things                                 !
+!                                                                      !
+!   C. D. Woodgate,  Warwick                                      2024 !
+!----------------------------------------------------------------------!
+module howto_examples 
+
+  use initialise
+  use kinds
+  use shared_data
+  use io
+  use comms
+  use c_functions
+  use energetics
+  use random_site
+  use analytics
+  use write_netcdf
+  use write_xyz
+  use write_diagnostics
+  use metropolis
+  
+  implicit none
+
+  contains
+
+  subroutine examples(setup, my_rank)
+
+    ! Rank of this processor
+    integer, intent(in) :: my_rank
+
+    ! Arrays for storing data
+    type(run_params) :: setup
+  
+    ! Integers used in calculations
+    integer :: i,j, div_steps, accept, n_save
+    
+    ! Temperature and temperature steps
+    real(real64) :: beta, temp, sim_temp, current_energy, step_E,     &
+                    step_Esq, C, acceptance
+  
+    ! Name of file for grid state and xyz file at this temperature
+    character(len=36) :: xyz_file
+
+    ! Name of file for writing diagnostics at the end
+    character(len=43) :: diagnostics_file
+  
+    ! Name of file for writing radial densities at the end
+    character(len=37) :: radial_file
+
+    ! This is for calculating radial density functions later
+    ! (It populates the array "shells".)
+    call lattice_shells(setup, shells, config)
+
+    ! Are we swapping just nearest-neighbours or 
+    ! allowing any pair of lattice sites?
+    if (setup%nbr_swap) then
+      setup%mc_step => monte_carlo_step_nbr
+    else
+      setup%mc_step => monte_carlo_step_lattice
+    end if
+
+    !----------!
+    ! EXAMPLES !
+    !----------!
+  
+    !--------------------------------------------!
+    ! 1. Initialise a random grid and display it !
+    !--------------------------------------------!
+
+    ! Set up the initial state of the grid (random occupancies)
+    ! on this rank. (Each rank works on different grid currently.)
+    call initial_setup(setup, config)
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' This is what the grid initially looks like: '
+      print*, ' '
+    end if
+  
+    ! You can see what it looks like (sort of) using this routine
+    call display_grid(config)
+
+    !---------------------------------!
+    ! 2. Perform a Metropolis MC step !
+    !---------------------------------!
+
+    ! Would normally use j to loop over temperatures
+    j = 1
+
+    ! Work out the temperature and corresponding beta
+    temp = setup%T + real(j-1, real64)*setup%delta_T
+    sim_temp = temp*k_b_in_Ry
+    beta = 1.0_real64/sim_temp
+    
+    do while (accept .lt. 0.5_real64)
+          accept = setup%mc_step(config, beta)
+    end do
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' This is what the grid looks like after one successful step: '
+      print*, ' '
+    end if
+
+    call display_grid(config)
+  
+    !---------------------------------------------------!
+    ! 3. Get the energy associated with a configuration !
+    !---------------------------------------------------!
+
+    current_energy = setup%full_energy(config)
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' The energy of that configuration is: ', current_energy, ' Ry'
+      print*, ' or: ', current_energy*13.606*1000.0, ' meV'
+      print*, ' or: ', current_energy*13.606*1000.0/setup%n_atoms, ' meV/atom'
+      print*, ' '
+    end if
+
+    !------------------------------------!
+    ! 4. Run some kind of equillibration !
+    !------------------------------------!
+    n_save=floor(real(setup%mc_steps)/real(setup%sample_steps))
+    div_steps = setup%mc_steps/1000
+
+    do i=1, setup%mc_steps
+    
+      ! Make one MC move
+      accept = setup%mc_step(config, beta)
+  
+      acceptance = acceptance + accept
+
+      ! Write percentage progress to screen
+      if (mod(i, setup%sample_steps) .eq. 0) then
+        current_energy = setup%full_energy(config)
+        step_E   = step_E + current_energy
+        step_Esq = step_Esq + current_energy**2
+      end if
+    
+    end do
+
+    ! Store the average energy per atom at this temperature
+    energies_of_T(j) = step_E/n_save/setup%n_atoms
+  
+    ! Heat capacity (per atom) at this temperature
+    C = (step_Esq/n_save - (step_E/n_save)**2)/(sim_temp*temp)/setup%n_atoms
+
+    ! Acceptance rate at this temperature
+    acceptance_of_T(j) = acceptance/real(setup%mc_steps)
+  
+    ! Store the specific heat capacity at this temperature
+    C_of_T(j) = C
+    
+    if (my_rank ==0) then
+      ! Write that we have completed a particular temperature
+      write(6,'(a,f7.2,a)',advance='yes') &
+      " Temperature ", temp, " complete on process 0."
+      write(6,'(a,f7.2,a)',advance='yes') &
+      " Internal energy was ", 13.606_real64*1000*energies_of_T(j), " meV/atom"
+      write(6,'(a,f9.4,a)',advance='yes') &
+      " Heat capacity was ", C_of_T(j)/k_B_in_Ry, " kB/atom"
+      write(6,'(a,f7.2,a,/)',advance='yes') &
+      " Swap acceptance rate was ", 100.0*acceptance_of_T(j), "%"
+    end if
+    
+    !------------------------------------!
+    ! 5. Write the grid to a .xyz file   !
+    !------------------------------------!
+
+    write(xyz_file, '(A11 I3.3 A12 I4.4 F2.1 A4)') 'grids/proc_', &
+    my_rank, 'config_at_T_', int(temp), temp-int(temp),'.xyz'
+  
+    ! Write xyz file
+    call xyz_writer(xyz_file, config, setup)
+  
+    !----------------------------------------------------------------!
+    ! 6. Compute the Warren-Cowley ASRO parameters and write to file !
+    !----------------------------------------------------------------!
+
+    ! Compute the radial densities at the end of this temperature
+    call radial_densities(setup, config, setup%wc_range, shells, rho_of_T, j)
+  
+    write(radial_file, '(A22 I3.3 A12)') 'radial_densities/proc_', my_rank, '_rho_of_T.nc'
+
+    ! Write the radial densities to file
+    call ncdf_radial_density_writer(radial_file, rho_of_T, &
+                                  shells, temperature, energies_of_T, setup)
+
+    if(my_rank == 0) then
+      write(6,'(25("-"),x,"Simulation Complete!",x,25("-"))')
+    end if
+  
+  end subroutine examples
+
+end module howto_examples 

--- a/src/initialise.f90
+++ b/src/initialise.f90
@@ -383,4 +383,5 @@ module initialise
 
   end subroutine initial_setup
 
+
 end module initialise

--- a/src/io.f90
+++ b/src/io.f90
@@ -290,9 +290,9 @@ module io
 
   end subroutine read_exchange
 
-  !-----------------------------------------------------!
-  ! Subroutine to read in exchange parameters from file !
-  !-----------------------------------------------------!
+  !------------------------------------------------------!
+  ! Subroutine to parse in exchange parameters from file !
+  !------------------------------------------------------!
   subroutine parse_inputs(setup, my_rank)
     type(run_params) :: setup
     integer :: my_rank
@@ -328,5 +328,77 @@ module io
     end if
 
   end subroutine parse_inputs
+
+  
+  !--------------------------------------------------------------------!
+  ! Subroutine to read and parse nested sampling control file          !
+  !                                                                    !
+  ! L. B. Partay, Warwick                                         2024 !
+  !--------------------------------------------------------------------!
+  subroutine read_ns_file(filename, parameters)
+    character(len=*), intent(in) :: filename
+    logical, dimension(8) :: check
+    type(ns_params) :: parameters
+    character(len=100) :: buffer, label
+    integer :: line, pos, ios
+
+    check = .false.
+
+    ios=0; line=0
+
+    open(25, file=filename, iostat=ios)
+
+    if (ios .ne. 0) then
+      stop 'Could not parse input file. Aborting...'
+    end if
+
+    write(*,'(a)', advance='no') new_line('a')
+    print*, '###############################'
+    print*, '#  Parsing NS input file      #'
+    print*, '###############################'
+
+    print*, '# NS input file name: ', filename
+
+    do while (ios==0)
+
+      read(25, "(A)", iostat=ios) buffer
+
+      if(ios==0) then
+        line=line+1
+
+        pos = scan(buffer, '=')
+        label=buffer(1:pos-1)
+        buffer = buffer(pos+1:)
+
+        select case (label)
+        case ('n_walkers')
+          read(buffer, *, iostat=ios) parameters%n_walkers
+          print*, '# Read n_walkers = ', parameters%n_walkers
+        case ('n_steps')
+          read(buffer, *, iostat=ios) parameters%n_steps
+          print*, '# Read n_steps = ', parameters%n_steps
+        case ('n_iter')
+          read(buffer, *, iostat=ios) parameters%n_iter
+          print*, '# Read n_iter = ', parameters%n_iter
+        case ('outfile_ener')
+          read(buffer, *, iostat=ios) parameters%outfile_ener
+          print*, '# Read outfile_ener = ', parameters%outfile_ener
+        case ('outfile_traj')
+          read(buffer, *, iostat=ios) parameters%outfile_traj
+          print*, '# Read outfile_traj = ', parameters%outfile_traj
+        case ('traj_freq')
+          read(buffer, *, iostat=ios) parameters%traj_freq
+          print*, '# Write configuration every n-th NS iteration = ', parameters%traj_freq
+        case default
+          print*, '# Skipping invalid label'
+        end select
+      end if
+    end do
+
+    print*, '# Finished parsing NS input file #'
+    print*, '###############################', new_line('a')
+    close(25)
+
+  end subroutine read_ns_file
 
 end module io

--- a/src/main.f90
+++ b/src/main.f90
@@ -26,7 +26,7 @@ program main
   type(run_params) :: setup
 
   ! Nested Sampling parameters type
-  type(ns_run_params) :: ns_setup
+  type(ns_params) :: ns_setup
 
   ! Start MPI
   call comms_initialise()
@@ -55,7 +55,7 @@ program main
   ! Initialise some global arrays
   call initialise_global_arrays(setup)
 
-  ! Initialise some global arrays
+  ! Initialise some local arrays
   call initialise_local_arrays(setup)
 
   !---------------!

--- a/src/main.f90
+++ b/src/main.f90
@@ -3,7 +3,7 @@
 !                                                                      !
 ! Main bontewarlo program.                                             !
 !                                                                      !
-! C. D. Woodgate,  Warwick                                        2023 !
+! C. D. Woodgate,  Warwick                                        2024 !
 !----------------------------------------------------------------------!
 program main
   
@@ -11,6 +11,7 @@ program main
   use comms
   use shared_data
   use metropolis
+  use nested_sampling
   use io
   use kinds
   use c_functions
@@ -23,6 +24,9 @@ program main
 
   ! Runtime parameters type
   type(run_params) :: setup
+
+  ! Nested Sampling parameters type
+  type(ns_run_params) :: ns_setup
 
   ! Start MPI
   call comms_initialise()
@@ -66,6 +70,11 @@ program main
 
     ! Draw decorrelated samples
     call metropolis_decorrelated_samples(setup, my_rank)
+
+  else if (setup%mode == 303) then
+
+    ! Nested Sampling algorithm
+    call nested_sampling_main(setup, ns_setup, my_rank)
 
   else
 

--- a/src/metropolis.f90
+++ b/src/metropolis.f90
@@ -324,7 +324,8 @@ module metropolis
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   function monte_carlo_step_lattice(setup, config, beta) result(accept)
-    integer(int16), allocatable, dimension(:,:,:,:) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:) :: config
+    integer(int16), dimension(:,:,:,:) :: config
     class(run_params), intent(in) :: setup
     integer :: accept
     integer, dimension(4) :: rdm1, rdm2
@@ -374,7 +375,8 @@ module metropolis
   ! C. D. Woodgate,  Warwick                                      2023 !
   !--------------------------------------------------------------------!
   function monte_carlo_step_nbr(setup, config, beta) result(accept)
-    integer(int16), allocatable, dimension(:,:,:,:) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:) :: config
+    integer(int16), dimension(:,:,:,:) :: config
     class(run_params), intent(in) :: setup
     integer :: accept
     integer, dimension(4) :: rdm1, rdm2

--- a/src/nested_sampling.f90
+++ b/src/nested_sampling.f90
@@ -31,223 +31,166 @@ module nested_sampling
   !                                                                    !
   ! L. B. Partay,  Warwick                                        2024 !
   !--------------------------------------------------------------------!
-  subroutine nested_sampling_main(setup, ns_setup, my_rank)
+  subroutine nested_sampling_main(setup, nested_sampling, my_rank)
 
-    ! Arrays for storing data
+    ! Arrays for storing instances of the system, as nested sampling walkers
     type(run_params) :: setup
-  
-    ! Arrays for storing data
-    type(ns_run_params) :: ns_setup
+    type(ns_params) :: nested_sampling
   
     ! Rank of this processor
     ! Redundant if we are in serial
     integer, intent(in) :: my_rank
 
-    ! Integers used in calculations
-    integer :: i,j, div_steps, accept, n_save
+    ! Energy before and after swap and change
+    real(real64) :: e_unswapped, e_swapped, delta_e, ener_limit, rnd
+    real(real64) :: acc_ratio, rnde
+    real(real64), dimension(:), allocatable :: walker_energies
+    ! Array for all the walkers configurations, with indices of n_base, n1, n2, n3, i_walker
+    integer(int16), dimension(:,:,:,:,:), allocatable :: ns_walkers
     
-    ! Temperature and temperature steps
-    real(real64) :: beta, temp, sim_temp, current_energy, step_E,     &
-                    step_Esq, C, acceptance
+    ! Occupancy of each site
+    integer(int16) :: site1, site2
+    integer :: i_walker, i_step, i_iter, irnd, n_at
+    integer :: n_acc, i_max(1), extra_steps
   
-    ! Name of file for grid state and xyz file at this temperature
-    character(len=36) :: xyz_file
+    ! Random lattice sites
+    integer, dimension(4) :: rdm1, rdm2
 
-    ! Name of file for writing diagnostics at the end
-    character(len=43) :: diagnostics_file
-  
-    ! Name of file for writing radial densities at the end
-    character(len=37) :: radial_file
+    ! open and parse input parameters needed for nested sampling
+    call read_ns_file("ns_input.txt", nested_sampling)
+    open(35,file=nested_sampling%outfile_ener)
 
-    ! This is for calculating radial density functions later
-    ! (It populates the array "shells".)
-    call lattice_shells(setup, shells, config)
+    ! creat arrays for storing all the NS walker configurations and their energies
+    allocate(ns_walkers(setup%n_basis, 2*setup%n_1, 2*setup%n_2, 2*setup%n_3,nested_sampling%n_walkers))
+    allocate(walker_energies(nested_sampling%n_walkers))
+    walker_energies=0.0d0
 
-    ! Are we swapping just nearest-neighbours or 
-    ! allowing any pair of lattice sites?
-    if (setup%nbr_swap) then
-      setup%mc_step => monte_carlo_step_nbr
-    else
-      setup%mc_step => monte_carlo_step_lattice
-    end if
+    ! initialise all walkers 
+    do i_walker = 1,nested_sampling%n_walkers
+    
+       ! Set up the energies file for ns_analyse post-procesing (script available from pymatnest package) 
+       if (i_walker == 1) then
+          n_at = setup%n_1*setup%n_2*setup%n_3*setup%n_basis*setup%n_species
+          ! header for energies file
+          write(35,*) nested_sampling%n_walkers, 1, 0, 'False', n_at
 
-    ! Routine goes here :-)
+       endif
+      
+       ! set up and generate initial random configurations for each walker
+       call initial_setup(setup, config)
+       ns_walkers(:,:,:,:,i_walker) = config
+       
+       ! Check the average concentrations
+       if (i_walker == 1) call print_particle_count(setup, ns_walkers(:,:,:,:,i_walker))
+    
+       ! Calculate all the inital energies and print to screen
+       ! Add small random number to the energy to avoid configurations to be degenerate in energy
+       call random_number(rnde)
+       walker_energies(i_walker)=setup%full_energy(ns_walkers(:,:,:,:,i_walker))+rnde*1e-8
+       print*, 'Energy', i_walker, 'is: ', walker_energies(i_walker)
+    
+    enddo
+    
+    extra_steps=0
+    
+    !---------------------------------!
+    ! Main NS iteration cycle         !
+    !---------------------------------!
+    print*, '********* MAIN NS CYCLE STARTS ************'
+    print*, 'Will do',nested_sampling%n_iter,'iterations, starting with', nested_sampling%n_steps,'MC steps initially.'
+    
+    do i_iter = 1, nested_sampling%n_iter
+    
+       ! find highest energy, which is saved and discarded from the list of walkers
+       i_max=maxloc(walker_energies)
+       ener_limit=walker_energies(i_max(1))
+    
+       ! save energy to NS ener output: nested_sampling%outfile_ener 
+       write(35,*) i_iter, ener_limit
+       ! save config to NS xyz output: nested_sampling%outfile_traj
+       if (mod(i_iter,nested_sampling%traj_freq)==0) then
+          call xyz_writer(nested_sampling%outfile_traj, ns_walkers(:,:,:,:,i_max(1)), setup, trajectory=.true.)
+       endif
+    
+       ! print sampling stage info to screen in every 0.5*number of walkers step
+       ! also adjust the number of attempted steps if the acceptance ratio is too low. 
+       if (mod(i_iter,int(nested_sampling%n_walkers/2.0))==0) then
+
+          ! acceptance ratio of the previous random walk      
+          acc_ratio=real(n_acc)/real(nested_sampling%n_steps+extra_steps)
+          
+          ! number of accepted steps should be such that 5% of atoms are moved
+          if ((n_acc < n_at*0.05).and.(extra_steps<nested_sampling%n_steps*100)) then
+             ! increase the extra steps to increase attempted steps
+             extra_steps = extra_steps+int(nested_sampling%n_steps)
+             print*, i_iter, ener_limit, acc_ratio, n_acc,'n_steps increased to', &
+                    & nested_sampling%n_steps+extra_steps
+          else 
+             print*, i_iter, ener_limit, acc_ratio, n_acc
+          endif
+
+       endif
+    
+       ! Generate a new sample, starting from an existing walker and doing a set of random steps
+
+       ! pick configuration for cloning
+       call random_number(rnd)
+       irnd=ceiling(rnd*nested_sampling%n_walkers)
+       ns_walkers(:,:,:,:,i_max(1)) = ns_walkers(:,:,:,:,irnd)
+       walker_energies(i_max(1)) = walker_energies(irnd)
+    
+       n_acc=0
+       i_step=0
+       ! do random walk
+       do i_step = 1, nested_sampling%n_steps+extra_steps
+       
+          ! Pick random site 1 and get what atom type it accopies
+          rdm1 = setup%rdm_site()
+          site1 = ns_walkers(rdm1(1), rdm1(2), rdm1(3), rdm1(4),i_max(1))
+          do 
+             ! Generate random site 2 that has different atom type
+             rdm2 = setup%rdm_site()
+             !if (acc_ratio < 0.01) then
+             !   rdm2 = ns_setup(i_max(1))%rdm_nbr(rdm1)
+             !else
+             !   rdm2 = ns_setup(i_max(1))%rdm_site()
+             !endif
+            
+             site2 = ns_walkers(rdm2(1), rdm2(2), rdm2(3), rdm2(4),i_max(1))
+             if (site1 /= site2) exit ! if same type, try again
+          enddo
+    
+          ! Compute the energies before and after and work out the change
+          e_unswapped = pair_energy(setup, ns_walkers(:,:,:,:,i_max(1)), rdm1, rdm2)
+          call pair_swap(ns_walkers(:,:,:,:,i_max(1)), rdm1, rdm2)
+          e_swapped = pair_energy(setup, ns_walkers(:,:,:,:,i_max(1)), rdm1, rdm2)
+    
+          ! since we are always swapping different atom types, the delta_e cannot be zero
+          delta_e = e_swapped - e_unswapped
+          write(*,*) delta_e
+    
+          if (walker_energies(i_max(1))+delta_e < ener_limit) then
+             !accept
+             walker_energies(i_max(1))=walker_energies(i_max(1))+delta_e
+             n_acc = n_acc+1
+          else
+             !reject (swap pairs back)
+             call pair_swap(ns_walkers(:,:,:,:,i_max(1)), rdm1, rdm2)
+          endif
+    
+       enddo
+       if (n_acc==0) then
+         write(*,*) "WARNING! None of the attempted swaps were accepted, hence the cloned configuration", &
+                    & "remained identical to the parent."
+         write(*,*) "Consider: increasing the number of steps, use a different strategy for swapping pair or", &
+                    & "decreasing the number of NS iterations (might have reached low enough energies?)"         
+       endif        
+    
+    enddo
+    print*, 'All NS iterations are done, sampling finished.'
+    close(35)
+    
   
   end subroutine nested_sampling_main
-
-  !--------------------------------------------------------------------!
-  ! Examples of how to do basic things                                 !
-  !                                                                    !
-  ! C. D. Woodgate,  Warwick                                      2024 !
-  !--------------------------------------------------------------------!
-  subroutine examples(setup, my_rank)
-
-    ! Rank of this processor
-    integer, intent(in) :: my_rank
-
-    ! Arrays for storing data
-    type(run_params) :: setup
-  
-    ! Integers used in calculations
-    integer :: i,j, div_steps, accept, n_save
-    
-    ! Temperature and temperature steps
-    real(real64) :: beta, temp, sim_temp, current_energy, step_E,     &
-                    step_Esq, C, acceptance
-  
-    ! Name of file for grid state and xyz file at this temperature
-    character(len=36) :: xyz_file
-
-    ! Name of file for writing diagnostics at the end
-    character(len=43) :: diagnostics_file
-  
-    ! Name of file for writing radial densities at the end
-    character(len=37) :: radial_file
-
-    ! This is for calculating radial density functions later
-    ! (It populates the array "shells".)
-    call lattice_shells(setup, shells, config)
-
-    ! Are we swapping just nearest-neighbours or 
-    ! allowing any pair of lattice sites?
-    if (setup%nbr_swap) then
-      setup%mc_step => monte_carlo_step_nbr
-    else
-      setup%mc_step => monte_carlo_step_lattice
-    end if
-
-    !----------!
-    ! EXAMPLES !
-    !----------!
-  
-    !--------------------------------------------!
-    ! 1. Initialise a random grid and display it !
-    !--------------------------------------------!
-
-    ! Set up the initial state of the grid (random occupancies)
-    ! on this rank. (Each rank works on different grid currently.)
-    call initial_setup(setup, config)
-
-    if(my_rank == 0) then
-      print*, ' '
-      print*, ' This is what the grid initially looks like: '
-      print*, ' '
-    end if
-  
-    ! You can see what it looks like (sort of) using this routine
-    call display_grid(config)
-
-    !---------------------------------!
-    ! 2. Perform a Metropolis MC step !
-    !---------------------------------!
-
-    ! Would normally use j to loop over temperatures
-    j = 1
-
-    ! Work out the temperature and corresponding beta
-    temp = setup%T + real(j-1, real64)*setup%delta_T
-    sim_temp = temp*k_b_in_Ry
-    beta = 1.0_real64/sim_temp
-    
-    do while (accept .lt. 0.5_real64)
-          accept = setup%mc_step(config, beta)
-    end do
-
-    if(my_rank == 0) then
-      print*, ' '
-      print*, ' This is what the grid looks like after one successful step: '
-      print*, ' '
-    end if
-
-    call display_grid(config)
-  
-    !---------------------------------------------------!
-    ! 3. Get the energy associated with a configuration !
-    !---------------------------------------------------!
-
-    current_energy = setup%full_energy(config)
-
-    if(my_rank == 0) then
-      print*, ' '
-      print*, ' The energy of that configuration is: ', current_energy, ' Ry'
-      print*, ' or: ', current_energy*13.606*1000.0, ' meV'
-      print*, ' or: ', current_energy*13.606*1000.0/setup%n_atoms, ' meV/atom'
-      print*, ' '
-    end if
-
-    !------------------------------------!
-    ! 4. Run some kind of equillibration !
-    !------------------------------------!
-    n_save=floor(real(setup%mc_steps)/real(setup%sample_steps))
-    div_steps = setup%mc_steps/1000
-
-    do i=1, setup%mc_steps
-    
-      ! Make one MC move
-      accept = setup%mc_step(config, beta)
-  
-      acceptance = acceptance + accept
-
-      ! Write percentage progress to screen
-      if (mod(i, setup%sample_steps) .eq. 0) then
-        current_energy = setup%full_energy(config)
-        step_E   = step_E + current_energy
-        step_Esq = step_Esq + current_energy**2
-      end if
-    
-    end do
-
-    ! Store the average energy per atom at this temperature
-    energies_of_T(j) = step_E/n_save/setup%n_atoms
-  
-    ! Heat capacity (per atom) at this temperature
-    C = (step_Esq/n_save - (step_E/n_save)**2)/(sim_temp*temp)/setup%n_atoms
-
-    ! Acceptance rate at this temperature
-    acceptance_of_T(j) = acceptance/real(setup%mc_steps)
-  
-    ! Store the specific heat capacity at this temperature
-    C_of_T(j) = C
-    
-    if (my_rank ==0) then
-      ! Write that we have completed a particular temperature
-      write(6,'(a,f7.2,a)',advance='yes') &
-      " Temperature ", temp, " complete on process 0."
-      write(6,'(a,f7.2,a)',advance='yes') &
-      " Internal energy was ", 13.606_real64*1000*energies_of_T(j), " meV/atom"
-      write(6,'(a,f9.4,a)',advance='yes') &
-      " Heat capacity was ", C_of_T(j)/k_B_in_Ry, " kB/atom"
-      write(6,'(a,f7.2,a,/)',advance='yes') &
-      " Swap acceptance rate was ", 100.0*acceptance_of_T(j), "%"
-    end if
-    
-    !------------------------------------!
-    ! 5. Write the grid to a .xyz file   !
-    !------------------------------------!
-
-    write(xyz_file, '(A11 I3.3 A12 I4.4 F2.1 A4)') 'grids/proc_', &
-    my_rank, 'config_at_T_', int(temp), temp-int(temp),'.xyz'
-  
-    ! Write xyz file
-    call xyz_writer(xyz_file, config, setup)
-  
-    !----------------------------------------------------------------!
-    ! 6. Compute the Warren-Cowley ASRO parameters and write to file !
-    !----------------------------------------------------------------!
-
-    ! Compute the radial densities at the end of this temperature
-    call radial_densities(setup, config, setup%wc_range, shells, rho_of_T, j)
-  
-    write(radial_file, '(A22 I3.3 A12)') 'radial_densities/proc_', my_rank, '_rho_of_T.nc'
-
-    ! Write the radial densities to file
-    call ncdf_radial_density_writer(radial_file, rho_of_T, &
-                                  shells, temperature, energies_of_T, setup)
-
-    if(my_rank == 0) then
-      write(6,'(25("-"),x,"Simulation Complete!",x,25("-"))')
-    end if
-  
-  end subroutine examples
 
 end module nested_sampling

--- a/src/nested_sampling.f90
+++ b/src/nested_sampling.f90
@@ -1,0 +1,253 @@
+!----------------------------------------------------------------------!
+! nested_sampling.f90                                                  !
+!                                                                      !
+! Module containing routines implementing the Nested Sampling          !
+! algorithm.                                                           !
+!                                                                      !
+! L. B. Partay,  Warwick                                          2024 !
+!----------------------------------------------------------------------!
+module nested_sampling
+
+  use initialise
+  use kinds
+  use shared_data
+  use io
+  use comms
+  use c_functions
+  use energetics
+  use random_site
+  use analytics
+  use write_netcdf
+  use write_xyz
+  use write_diagnostics
+  use metropolis
+  
+  implicit none
+
+  contains
+
+  !--------------------------------------------------------------------!
+  ! Main nested sampling routine.                                      !
+  !                                                                    !
+  ! L. B. Partay,  Warwick                                        2024 !
+  !--------------------------------------------------------------------!
+  subroutine nested_sampling_main(setup, ns_setup, my_rank)
+
+    ! Arrays for storing data
+    type(run_params) :: setup
+  
+    ! Arrays for storing data
+    type(ns_run_params) :: ns_setup
+  
+    ! Rank of this processor
+    ! Redundant if we are in serial
+    integer, intent(in) :: my_rank
+
+    ! Integers used in calculations
+    integer :: i,j, div_steps, accept, n_save
+    
+    ! Temperature and temperature steps
+    real(real64) :: beta, temp, sim_temp, current_energy, step_E,     &
+                    step_Esq, C, acceptance
+  
+    ! Name of file for grid state and xyz file at this temperature
+    character(len=36) :: xyz_file
+
+    ! Name of file for writing diagnostics at the end
+    character(len=43) :: diagnostics_file
+  
+    ! Name of file for writing radial densities at the end
+    character(len=37) :: radial_file
+
+    ! This is for calculating radial density functions later
+    ! (It populates the array "shells".)
+    call lattice_shells(setup, shells, config)
+
+    ! Are we swapping just nearest-neighbours or 
+    ! allowing any pair of lattice sites?
+    if (setup%nbr_swap) then
+      setup%mc_step => monte_carlo_step_nbr
+    else
+      setup%mc_step => monte_carlo_step_lattice
+    end if
+
+    ! Routine goes here :-)
+  
+  end subroutine nested_sampling_main
+
+  !--------------------------------------------------------------------!
+  ! Examples of how to do basic things                                 !
+  !                                                                    !
+  ! C. D. Woodgate,  Warwick                                      2024 !
+  !--------------------------------------------------------------------!
+  subroutine examples(setup, my_rank)
+
+    ! Rank of this processor
+    integer, intent(in) :: my_rank
+
+    ! Arrays for storing data
+    type(run_params) :: setup
+  
+    ! Integers used in calculations
+    integer :: i,j, div_steps, accept, n_save
+    
+    ! Temperature and temperature steps
+    real(real64) :: beta, temp, sim_temp, current_energy, step_E,     &
+                    step_Esq, C, acceptance
+  
+    ! Name of file for grid state and xyz file at this temperature
+    character(len=36) :: xyz_file
+
+    ! Name of file for writing diagnostics at the end
+    character(len=43) :: diagnostics_file
+  
+    ! Name of file for writing radial densities at the end
+    character(len=37) :: radial_file
+
+    ! This is for calculating radial density functions later
+    ! (It populates the array "shells".)
+    call lattice_shells(setup, shells, config)
+
+    ! Are we swapping just nearest-neighbours or 
+    ! allowing any pair of lattice sites?
+    if (setup%nbr_swap) then
+      setup%mc_step => monte_carlo_step_nbr
+    else
+      setup%mc_step => monte_carlo_step_lattice
+    end if
+
+    !----------!
+    ! EXAMPLES !
+    !----------!
+  
+    !--------------------------------------------!
+    ! 1. Initialise a random grid and display it !
+    !--------------------------------------------!
+
+    ! Set up the initial state of the grid (random occupancies)
+    ! on this rank. (Each rank works on different grid currently.)
+    call initial_setup(setup, config)
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' This is what the grid initially looks like: '
+      print*, ' '
+    end if
+  
+    ! You can see what it looks like (sort of) using this routine
+    call display_grid(config)
+
+    !---------------------------------!
+    ! 2. Perform a Metropolis MC step !
+    !---------------------------------!
+
+    ! Would normally use j to loop over temperatures
+    j = 1
+
+    ! Work out the temperature and corresponding beta
+    temp = setup%T + real(j-1, real64)*setup%delta_T
+    sim_temp = temp*k_b_in_Ry
+    beta = 1.0_real64/sim_temp
+    
+    do while (accept .lt. 0.5_real64)
+          accept = setup%mc_step(config, beta)
+    end do
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' This is what the grid looks like after one successful step: '
+      print*, ' '
+    end if
+
+    call display_grid(config)
+  
+    !---------------------------------------------------!
+    ! 3. Get the energy associated with a configuration !
+    !---------------------------------------------------!
+
+    current_energy = setup%full_energy(config)
+
+    if(my_rank == 0) then
+      print*, ' '
+      print*, ' The energy of that configuration is: ', current_energy, ' Ry'
+      print*, ' or: ', current_energy*13.606*1000.0, ' meV'
+      print*, ' or: ', current_energy*13.606*1000.0/setup%n_atoms, ' meV/atom'
+      print*, ' '
+    end if
+
+    !------------------------------------!
+    ! 4. Run some kind of equillibration !
+    !------------------------------------!
+    n_save=floor(real(setup%mc_steps)/real(setup%sample_steps))
+    div_steps = setup%mc_steps/1000
+
+    do i=1, setup%mc_steps
+    
+      ! Make one MC move
+      accept = setup%mc_step(config, beta)
+  
+      acceptance = acceptance + accept
+
+      ! Write percentage progress to screen
+      if (mod(i, setup%sample_steps) .eq. 0) then
+        current_energy = setup%full_energy(config)
+        step_E   = step_E + current_energy
+        step_Esq = step_Esq + current_energy**2
+      end if
+    
+    end do
+
+    ! Store the average energy per atom at this temperature
+    energies_of_T(j) = step_E/n_save/setup%n_atoms
+  
+    ! Heat capacity (per atom) at this temperature
+    C = (step_Esq/n_save - (step_E/n_save)**2)/(sim_temp*temp)/setup%n_atoms
+
+    ! Acceptance rate at this temperature
+    acceptance_of_T(j) = acceptance/real(setup%mc_steps)
+  
+    ! Store the specific heat capacity at this temperature
+    C_of_T(j) = C
+    
+    if (my_rank ==0) then
+      ! Write that we have completed a particular temperature
+      write(6,'(a,f7.2,a)',advance='yes') &
+      " Temperature ", temp, " complete on process 0."
+      write(6,'(a,f7.2,a)',advance='yes') &
+      " Internal energy was ", 13.606_real64*1000*energies_of_T(j), " meV/atom"
+      write(6,'(a,f9.4,a)',advance='yes') &
+      " Heat capacity was ", C_of_T(j)/k_B_in_Ry, " kB/atom"
+      write(6,'(a,f7.2,a,/)',advance='yes') &
+      " Swap acceptance rate was ", 100.0*acceptance_of_T(j), "%"
+    end if
+    
+    !------------------------------------!
+    ! 5. Write the grid to a .xyz file   !
+    !------------------------------------!
+
+    write(xyz_file, '(A11 I3.3 A12 I4.4 F2.1 A4)') 'grids/proc_', &
+    my_rank, 'config_at_T_', int(temp), temp-int(temp),'.xyz'
+  
+    ! Write xyz file
+    call xyz_writer(xyz_file, config, setup)
+  
+    !----------------------------------------------------------------!
+    ! 6. Compute the Warren-Cowley ASRO parameters and write to file !
+    !----------------------------------------------------------------!
+
+    ! Compute the radial densities at the end of this temperature
+    call radial_densities(setup, config, setup%wc_range, shells, rho_of_T, j)
+  
+    write(radial_file, '(A22 I3.3 A12)') 'radial_densities/proc_', my_rank, '_rho_of_T.nc'
+
+    ! Write the radial densities to file
+    call ncdf_radial_density_writer(radial_file, rho_of_T, &
+                                  shells, temperature, energies_of_T, setup)
+
+    if(my_rank == 0) then
+      write(6,'(25("-"),x,"Simulation Complete!",x,25("-"))')
+    end if
+  
+  end subroutine examples
+
+end module nested_sampling

--- a/src/random_site.f90
+++ b/src/random_site.f90
@@ -158,7 +158,8 @@ module random_site
   ! Function to compute energy of swapping a pair !
   !-----------------------------------------------!
   subroutine pair_swap(config, idx1, idx2)
-    integer(int16), allocatable, dimension(:,:,:,:) :: config
+    !integer(int16), allocatable, dimension(:,:,:,:) :: config
+    integer(int16), dimension(:,:,:,:) :: config
     integer, dimension(4), intent(in) :: idx1, idx2
     integer(int16) :: species1, species2
 

--- a/src/shared_data.f90
+++ b/src/shared_data.f90
@@ -100,6 +100,15 @@ module shared_data
   end type run_params
 
   !--------------------------------------------------------------------!
+  ! Type storing parameters defining NS simulation (used at runtime)   !
+  !                                                                    !
+  ! L. B. Partay,  Warwick                                        2024 !
+  !--------------------------------------------------------------------!
+  type ns_run_params
+    integer :: a_thing
+  end type ns_run_params
+
+  !--------------------------------------------------------------------!
   ! Interface for neighbour implementation                             !
   !                                                                    !
   ! C. D. Woodgate,  Warwick                                      2023 !

--- a/src/shared_data.f90
+++ b/src/shared_data.f90
@@ -104,9 +104,18 @@ module shared_data
   !                                                                    !
   ! L. B. Partay,  Warwick                                        2024 !
   !--------------------------------------------------------------------!
-  type ns_run_params
-    integer :: a_thing
-  end type ns_run_params
+  type ns_params
+    ! Number of nested sampling walkers
+    integer :: n_walkers
+    ! Number of steps required for walk generating a new configuration
+    integer :: n_steps
+    ! Number of NS iterations before sampling is finished
+    integer :: n_iter
+    ! Frequency of writing configuration (every traj_freq-th NS iteration)
+    integer :: traj_freq
+    ! Output filenames
+    character(len=100) :: outfile_ener, outfile_traj  
+  end type ns_params
 
   !--------------------------------------------------------------------!
   ! Interface for neighbour implementation                             !
@@ -119,7 +128,8 @@ module shared_data
     function hamiltonian(setup, config)
       use kinds
       import :: run_params
-      integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+      !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+      integer(int16), dimension(:,:,:,:), intent(in) :: config
       real(real64) :: hamiltonian
       class(run_params), intent(in) :: setup
     end function
@@ -128,7 +138,8 @@ module shared_data
     function neighbour(setup, config, site_i, site_j, site_k)
       use kinds
       import :: run_params
-      integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+      !integer(int16), allocatable, dimension(:,:,:,:), intent(in) :: config
+      integer(int16), dimension(:,:,:,:), intent(in) :: config
       real(real64) :: neighbour
       class(run_params), intent(in) :: setup
       integer, intent(in) :: site_i, site_j, site_k
@@ -155,7 +166,8 @@ module shared_data
     function monte_carlo(setup, config, beta) result(accept)
       use kinds
       import :: run_params
-      integer(int16), allocatable, dimension(:,:,:,:) :: config
+      !integer(int16), allocatable, dimension(:,:,:,:) :: config
+      integer(int16), dimension(:,:,:,:) :: config
       class(run_params), intent(in) :: setup
       integer :: accept
       real(real64), intent(in) :: beta

--- a/src/write_xyz.f90
+++ b/src/write_xyz.f90
@@ -16,16 +16,22 @@ module write_xyz
   contains
 
   !--------------------------------------------------------------------!
-  ! Routine to write xyz file                                          !
+  ! Routine to write xyz file, with option to append configurations in !
+  ! a single trajectory file.                                          !
   !                                                                    !
   ! C. D. Woodgate,  Warwick                                      2023 !
+  ! L. B. Partay,    Warwick                                      2024 !
   !--------------------------------------------------------------------!
-  subroutine xyz_writer(filename, configuration, setup)
+  subroutine xyz_writer(filename, configuration, setup, trajectory)
     ! Simulation setup information
     type(run_params), intent(in) :: setup
 
     ! Data to write to file
-    integer(int16), dimension(:,:,:,:), allocatable, intent(in) :: configuration
+    !integer(int16), dimension(:,:,:,:), allocatable, intent(in) :: configuration
+    integer(int16), dimension(:,:,:,:), intent(in) :: configuration
+
+    ! Option to open existing xyz file and append new configuration to the end
+    logical, optional :: trajectory
 
     ! Sizes of grid
     integer, dimension(4) :: grid_sizes
@@ -34,18 +40,42 @@ module write_xyz
     character(len=*), intent(in) :: filename
 
     integer :: n_particles, i, j, k, l
-
+    logical :: exist
     real(real64), dimension(3) :: pos
 
     n_particles = total_particle_count(setup, configuration)
 
     grid_sizes = shape(configuration)
 
-    open(unit=7, file=filename)
+    ! Check if we want to open new xyz, overwrite existing xyz or append existing xyz file
+    if (present(trajectory)) then
+
+      if (trajectory) then
+        inquire(file=filename, exist=exist)
+        if (exist) then
+          open(7, file=filename, status="old", position="append", action="write")
+        else
+          open(7, file=filename, status="new", action="write")
+        end if      
+      end if
+
+    else ! open xyz (if exists, will ovrewrite)
+
+      open(unit=7, file=filename)
+
+    endif  
 
     write(7, *) n_particles
 
-    write(7,*) ''
+    if (present(trajectory)) then
+      if (trajectory) then
+        write(7,*) 'Lattice="',setup%lattice_parameter*setup%n_1, 0.0, 0.0 , &
+                       &   0.0, setup%lattice_parameter*setup%n_2, 0.0 , &
+                       &   0.0, 0.0, setup%lattice_parameter*setup%n_3,     '"'
+      end if          
+    else           
+      write(7,*) ''
+    end if
 
     do i=1, grid_sizes(1)
       do j=1, grid_sizes(2)


### PR DESCRIPTION
New option: running nested sampling calculation. This only works in serial, requires an additional input file (currently expects ns_input.txt as filename for this).
Some variables are updated, and array allocations commented out when not necessary, to allow nested sampling walkers to be stored in an array. 
Example snippets are copied to a new howto f90 file, but this is not added to the Makefile